### PR TITLE
Add consumption deviation benchmarks and improved table formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ All notable changes to this project will be documented in this file.
 * `experiments/retirement/retirement_timings.sh`: Configurable bash wrapper with sweep settings
 * `logs/` directory for HPC job output; added `temp/` and `archive/` to `.gitignore`
 
+* **Consumption deviation benchmarking** (PR #9):
+  - Added `consumption_deviation()` function in `retirement.py` to compare solutions against high-resolution "true" reference (default: 20k grid DCEGM)
+  - Metric uses same format as Euler error: `log₁₀(|c - c_true| / c_true)`
+  - Configurable `true_grid_size` and `true_method` parameters in YAML benchmark section
+  - Restructured benchmark tables into two cleaner formats:
+    * Timing table with UE/Tot sub-columns per method
+    * Accuracy table with Euler/Dev sub-columns per method
+  - Grid-grouped rows with delta as sub-rows for improved readability
+  - Renamed `l2` variables to `cdev` for clarity (consumption deviation, not L2 norm)
+
 ## [0.5.0dev0] - 2025-08-12 – Multi-GPU Support and FUES Algorithm Cleanup
 - [2025-08-16 10:00 AEST] Major refactoring: Removed MPI support from horses_c.py, removed unused F_ownc_cntn_to_dcsn factory, standardized terminology
 - [2025-08-17 17:00 AEST] Added DGX A100 support with specialized PBS scripts, GPU kernel optimizations, and log management utilities

--- a/examples/retirement/__init__.py
+++ b/examples/retirement/__init__.py
@@ -1,14 +1,14 @@
 """Retirement model example - FUES vs DC-EGM comparison."""
 
 from .plots import plot_egrids, plot_cons_pol, plot_dcegm_cf
-from .tables import generate_timing_table, generate_results_table
+from .tables import generate_timing_table_combined, generate_accuracy_table
 from .benchmarks import test_Timings
 
 __all__ = [
     'plot_egrids',
     'plot_cons_pol',
     'plot_dcegm_cf',
-    'generate_timing_table',
-    'generate_results_table',
+    'generate_timing_table_combined',
+    'generate_accuracy_table',
     'test_Timings',
 ]

--- a/examples/retirement/benchmarks.py
+++ b/examples/retirement/benchmarks.py
@@ -8,12 +8,13 @@ Author: Akshay Shanker, University of New South Wales, akshay.shanker@me.com
 import numpy as np
 import os
 
-from dc_smm.models.retirement.retirement import Operator_Factory, RetirementModel, euler
-from .tables import generate_timing_table, generate_results_table
+from dc_smm.models.retirement.retirement import Operator_Factory, RetirementModel, euler, consumption_deviation
+from .tables import generate_timing_table_combined, generate_accuracy_table
 from .plots import plot_egrids, plot_cons_pol, plot_dcegm_cf
 
 
-def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2):
+def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2,
+                 true_grid_size=20000, true_method='DCEGM'):
     """Run timing benchmarks across grid sizes and delta values.
 
     Parameters
@@ -28,6 +29,11 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
         Directory to save results. Default is "results".
     m_bar : float
         FUES jump detection threshold. Default is 1.2.
+    true_grid_size : int
+        Grid size for computing "true" reference solution. Default is 20000.
+    true_method : str
+        Method used for computing "true" reference solution. Default is 'DCEGM'.
+        Options: 'RFC', 'FUES', 'DCEGM', 'CONSAV'.
     """
     # Fixed parameters for the benchmark sweep
     benchmark_params = {
@@ -39,11 +45,42 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
         'grid_max_A': 500,
         'm_bar': m_bar,
         'smooth_sigma': 0,
+        'true_grid_size': true_grid_size,
+        'true_method': true_method,
     }
 
     latex_errors_data = []
     latex_timings_data = []
     latex_total_timing_data = []
+    latex_l2_data = []
+
+    # Pre-compute "true" solutions for each delta value
+    true_solutions = {}
+    for delta in delta_values:
+        print(f"\nComputing true solution for delta={delta} with {true_grid_size} grid points using {true_method}...")
+        cp_true = RetirementModel(
+            r=benchmark_params['r'],
+            beta=benchmark_params['beta'],
+            delta=delta,
+            y=benchmark_params['y'],
+            b=benchmark_params['b'],
+            grid_max_A=benchmark_params['grid_max_A'],
+            grid_size=true_grid_size,
+            T=benchmark_params['T'],
+            smooth_sigma=benchmark_params['smooth_sigma'],
+            m_bar=benchmark_params['m_bar'],
+            padding_mbar=-0.011,
+        )
+        _, _, iter_bell_true = Operator_Factory(cp_true)
+        # Warm-up run
+        _ = iter_bell_true(cp_true, method=true_method)
+        # Actual run
+        _, _, _, _, c_true, _, _ = iter_bell_true(cp_true, method=true_method)
+        true_solutions[delta] = {
+            'c_true': c_true,
+            'a_grid': cp_true.asset_grid_A
+        }
+        print(f"  True solution computed.")
 
     for g_size_baseline in grid_sizes:
         for delta in delta_values:
@@ -77,6 +114,14 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
             best_error_FUES = float('inf')
             best_error_DCEGM = float('inf')
             best_error_CONSAV = float('inf')
+            best_l2_RFC = float('inf')
+            best_l2_FUES = float('inf')
+            best_l2_DCEGM = float('inf')
+            best_l2_CONSAV = float('inf')
+
+            # Get true solution for this delta
+            c_true = true_solutions[delta]['c_true']
+            a_grid_true = true_solutions[delta]['a_grid']
 
             for _ in range(n):
                 # Test RFC
@@ -84,24 +129,28 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
                 time_end_RFC = np.mean(iter_time_age[0])
                 total_time_RFC = iter_time_age[1]
                 Euler_error_RFC = euler(cp, c_refined_RFC)
+                cons_dev_RFC = consumption_deviation(cp, c_refined_RFC, c_true, a_grid_true)
 
                 # Test FUES
                 _, _, _, _, c_refined_FUES, _, iter_time_age = iter_bell(cp, method='FUES')
                 time_end_FUES = np.mean(iter_time_age[0])
                 total_time_FUES = iter_time_age[1]
                 Euler_error_FUES = euler(cp, c_refined_FUES)
+                cons_dev_FUES = consumption_deviation(cp, c_refined_FUES, c_true, a_grid_true)
 
                 # Test DCEGM
                 _, _, _, _, c_refined_DCEGM, _, iter_time_age = iter_bell(cp, method='DCEGM')
                 time_end_DCEGM = np.mean(iter_time_age[0])
                 total_time_DCEGM = iter_time_age[1]
                 Euler_error_DCEGM = euler(cp, c_refined_DCEGM)
+                cons_dev_DCEGM = consumption_deviation(cp, c_refined_DCEGM, c_true, a_grid_true)
 
                 # Test CONSAV
                 _, _, _, _, c_refined_CONSAV, _, iter_time_age = iter_bell(cp, method='CONSAV')
                 time_end_CONSAV = np.mean(iter_time_age[0])
                 total_time_CONSAV = iter_time_age[1]
                 Euler_error_CONSAV = euler(cp, c_refined_CONSAV)
+                cons_dev_CONSAV = consumption_deviation(cp, c_refined_CONSAV, c_true, a_grid_true)
 
                 # Take the best of n runs
                 best_time_RFC = min(best_time_RFC, time_end_RFC)
@@ -119,6 +168,11 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
                 best_error_DCEGM = min(best_error_DCEGM, Euler_error_DCEGM)
                 best_error_CONSAV = min(best_error_CONSAV, Euler_error_CONSAV)
 
+                best_l2_RFC = min(best_l2_RFC, cons_dev_RFC)
+                best_l2_FUES = min(best_l2_FUES, cons_dev_FUES)
+                best_l2_DCEGM = min(best_l2_DCEGM, cons_dev_DCEGM)
+                best_l2_CONSAV = min(best_l2_CONSAV, cons_dev_CONSAV)
+
             latex_errors_data.append([
                 g_size_baseline, delta, best_error_RFC,
                 best_error_FUES, best_error_DCEGM, best_error_CONSAV
@@ -132,23 +186,31 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
                 best_total_time_FUES * 1000, best_total_time_DCEGM * 1000,
                 best_total_time_CONSAV * 1000
             ])
+            latex_l2_data.append([
+                g_size_baseline, delta, best_l2_RFC,
+                best_l2_FUES, best_l2_DCEGM, best_l2_CONSAV
+            ])
 
             print(
                 f'Euler errors: RFC: {best_error_RFC:.6f}, FUES: {best_error_FUES:.6f}, '
                 f'DCEGM: {best_error_DCEGM:.6f}, CONSAV: {best_error_CONSAV:.6f}'
             )
             print(
+                f'Cons. dev (log10): RFC: {best_l2_RFC:.6f}, FUES: {best_l2_FUES:.6f}, '
+                f'DCEGM: {best_l2_DCEGM:.6f}, CONSAV: {best_l2_CONSAV:.6f}'
+            )
+            print(
                 f'Timings (s): RFC: {best_time_RFC:.6f}, FUES: {best_time_FUES:.6f}, '
                 f'DCEGM: {best_time_DCEGM:.6f}, CONSAV: {best_time_CONSAV:.6f}'
             )
 
-    # Generate markdown tables with parameter caption
-    generate_results_table(latex_timings_data, latex_errors_data,
-                          "timing", "Retirement model", results_dir,
-                          params=benchmark_params)
-    generate_timing_table(latex_total_timing_data, "total_timing",
-                         "Retirement model", results_dir,
-                         params=benchmark_params)
+    # Generate tables with sub-columns
+    generate_timing_table_combined(latex_timings_data, latex_total_timing_data,
+                                   "timing", "Retirement model", results_dir,
+                                   params=benchmark_params)
+    generate_accuracy_table(latex_errors_data, latex_l2_data,
+                            "accuracy", "Retirement model", results_dir,
+                            params=benchmark_params)
 
 
 if __name__ == "__main__":

--- a/examples/retirement/benchmarks.py
+++ b/examples/retirement/benchmarks.py
@@ -52,7 +52,7 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
     latex_errors_data = []
     latex_timings_data = []
     latex_total_timing_data = []
-    latex_l2_data = []
+    latex_cons_dev_data = []
 
     # Pre-compute "true" solutions for each delta value
     true_solutions = {}
@@ -114,10 +114,10 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
             best_error_FUES = float('inf')
             best_error_DCEGM = float('inf')
             best_error_CONSAV = float('inf')
-            best_l2_RFC = float('inf')
-            best_l2_FUES = float('inf')
-            best_l2_DCEGM = float('inf')
-            best_l2_CONSAV = float('inf')
+            best_cons_dev_RFC = float('inf')
+            best_cons_dev_FUES = float('inf')
+            best_cons_dev_DCEGM = float('inf')
+            best_cons_dev_CONSAV = float('inf')
 
             # Get true solution for this delta
             c_true = true_solutions[delta]['c_true']
@@ -168,10 +168,10 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
                 best_error_DCEGM = min(best_error_DCEGM, Euler_error_DCEGM)
                 best_error_CONSAV = min(best_error_CONSAV, Euler_error_CONSAV)
 
-                best_l2_RFC = min(best_l2_RFC, cons_dev_RFC)
-                best_l2_FUES = min(best_l2_FUES, cons_dev_FUES)
-                best_l2_DCEGM = min(best_l2_DCEGM, cons_dev_DCEGM)
-                best_l2_CONSAV = min(best_l2_CONSAV, cons_dev_CONSAV)
+                best_cons_dev_RFC = min(best_cons_dev_RFC, cons_dev_RFC)
+                best_cons_dev_FUES = min(best_cons_dev_FUES, cons_dev_FUES)
+                best_cons_dev_DCEGM = min(best_cons_dev_DCEGM, cons_dev_DCEGM)
+                best_cons_dev_CONSAV = min(best_cons_dev_CONSAV, cons_dev_CONSAV)
 
             latex_errors_data.append([
                 g_size_baseline, delta, best_error_RFC,
@@ -186,9 +186,9 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
                 best_total_time_FUES * 1000, best_total_time_DCEGM * 1000,
                 best_total_time_CONSAV * 1000
             ])
-            latex_l2_data.append([
-                g_size_baseline, delta, best_l2_RFC,
-                best_l2_FUES, best_l2_DCEGM, best_l2_CONSAV
+            latex_cons_dev_data.append([
+                g_size_baseline, delta, best_cons_dev_RFC,
+                best_cons_dev_FUES, best_cons_dev_DCEGM, best_cons_dev_CONSAV
             ])
 
             print(
@@ -196,8 +196,8 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
                 f'DCEGM: {best_error_DCEGM:.6f}, CONSAV: {best_error_CONSAV:.6f}'
             )
             print(
-                f'Cons. dev (log10): RFC: {best_l2_RFC:.6f}, FUES: {best_l2_FUES:.6f}, '
-                f'DCEGM: {best_l2_DCEGM:.6f}, CONSAV: {best_l2_CONSAV:.6f}'
+                f'Cons. dev (log10): RFC: {best_cons_dev_RFC:.6f}, FUES: {best_cons_dev_FUES:.6f}, '
+                f'DCEGM: {best_cons_dev_DCEGM:.6f}, CONSAV: {best_cons_dev_CONSAV:.6f}'
             )
             print(
                 f'Timings (s): RFC: {best_time_RFC:.6f}, FUES: {best_time_FUES:.6f}, '
@@ -208,7 +208,7 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
     generate_timing_table_combined(latex_timings_data, latex_total_timing_data,
                                    "timing", "Retirement model", results_dir,
                                    params=benchmark_params)
-    generate_accuracy_table(latex_errors_data, latex_l2_data,
+    generate_accuracy_table(latex_errors_data, latex_cons_dev_data,
                             "accuracy", "Retirement model", results_dir,
                             params=benchmark_params)
 

--- a/examples/retirement/benchmarks.py
+++ b/examples/retirement/benchmarks.py
@@ -52,7 +52,7 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
     latex_errors_data = []
     latex_timings_data = []
     latex_total_timing_data = []
-    latex_l2_data = []
+    latex_cdev_data = []
 
     # Pre-compute "true" solutions for each delta value
     true_solutions = {}
@@ -114,10 +114,10 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
             best_error_FUES = float('inf')
             best_error_DCEGM = float('inf')
             best_error_CONSAV = float('inf')
-            best_l2_RFC = float('inf')
-            best_l2_FUES = float('inf')
-            best_l2_DCEGM = float('inf')
-            best_l2_CONSAV = float('inf')
+            best_cdev_RFC = float('inf')
+            best_cdev_FUES = float('inf')
+            best_cdev_DCEGM = float('inf')
+            best_cdev_CONSAV = float('inf')
 
             # Get true solution for this delta
             c_true = true_solutions[delta]['c_true']
@@ -168,10 +168,10 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
                 best_error_DCEGM = min(best_error_DCEGM, Euler_error_DCEGM)
                 best_error_CONSAV = min(best_error_CONSAV, Euler_error_CONSAV)
 
-                best_l2_RFC = min(best_l2_RFC, cons_dev_RFC)
-                best_l2_FUES = min(best_l2_FUES, cons_dev_FUES)
-                best_l2_DCEGM = min(best_l2_DCEGM, cons_dev_DCEGM)
-                best_l2_CONSAV = min(best_l2_CONSAV, cons_dev_CONSAV)
+                best_cdev_RFC = min(best_cdev_RFC, cons_dev_RFC)
+                best_cdev_FUES = min(best_cdev_FUES, cons_dev_FUES)
+                best_cdev_DCEGM = min(best_cdev_DCEGM, cons_dev_DCEGM)
+                best_cdev_CONSAV = min(best_cdev_CONSAV, cons_dev_CONSAV)
 
             latex_errors_data.append([
                 g_size_baseline, delta, best_error_RFC,
@@ -186,9 +186,9 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
                 best_total_time_FUES * 1000, best_total_time_DCEGM * 1000,
                 best_total_time_CONSAV * 1000
             ])
-            latex_l2_data.append([
-                g_size_baseline, delta, best_l2_RFC,
-                best_l2_FUES, best_l2_DCEGM, best_l2_CONSAV
+            latex_cdev_data.append([
+                g_size_baseline, delta, best_cdev_RFC,
+                best_cdev_FUES, best_cdev_DCEGM, best_cdev_CONSAV
             ])
 
             print(
@@ -196,8 +196,8 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
                 f'DCEGM: {best_error_DCEGM:.6f}, CONSAV: {best_error_CONSAV:.6f}'
             )
             print(
-                f'Cons. dev (log10): RFC: {best_l2_RFC:.6f}, FUES: {best_l2_FUES:.6f}, '
-                f'DCEGM: {best_l2_DCEGM:.6f}, CONSAV: {best_l2_CONSAV:.6f}'
+                f'Cons. dev (log10): RFC: {best_cdev_RFC:.6f}, FUES: {best_cdev_FUES:.6f}, '
+                f'DCEGM: {best_cdev_DCEGM:.6f}, CONSAV: {best_cdev_CONSAV:.6f}'
             )
             print(
                 f'Timings (s): RFC: {best_time_RFC:.6f}, FUES: {best_time_FUES:.6f}, '
@@ -208,7 +208,7 @@ def test_Timings(grid_sizes, delta_values, n=3, results_dir="results", m_bar=1.2
     generate_timing_table_combined(latex_timings_data, latex_total_timing_data,
                                    "timing", "Retirement model", results_dir,
                                    params=benchmark_params)
-    generate_accuracy_table(latex_errors_data, latex_l2_data,
+    generate_accuracy_table(latex_errors_data, latex_cdev_data,
                             "accuracy", "Retirement model", results_dir,
                             params=benchmark_params)
 

--- a/examples/retirement/tables.py
+++ b/examples/retirement/tables.py
@@ -300,7 +300,7 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
     params : dict, optional
         Model parameters to include in caption.
     l2_data : list of lists, optional
-        Data for consumption deviation from true solution (20k grid DCEGM).
+        Data for consumption deviation from reference solution.
         Each row: [grid_size, delta, rfc_cdev, fues_cdev, dcegm_cdev, consav_cdev]
     """
     os.makedirs(results_dir, exist_ok=True)

--- a/examples/retirement/tables.py
+++ b/examples/retirement/tables.py
@@ -402,15 +402,15 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
 
         if include_l2:
             l2_row = l2_data[i]
-            rfc_l2 = l2_row[2]
-            fues_l2 = l2_row[3]
-            dcegm_l2 = l2_row[4]
-            consav_l2 = l2_row[5]
+            rfc_cdev = l2_row[2]
+            fues_cdev = l2_row[3]
+            dcegm_cdev = l2_row[4]
+            consav_cdev = l2_row[5]
             tex_lines.append(
                 f"{grid_size} & {delta:.2f} & {rfc_time:.3f} & {fues_time:.3f} & "
                 f"{dcegm_time:.3f} & {consav_time:.3f} & {rfc_error:.3f} & "
                 f"{fues_error:.3f} & {dcegm_error:.3f} & {consav_error:.3f} & "
-                f"{rfc_l2:.3f} & {fues_l2:.3f} & {dcegm_l2:.3f} & {consav_l2:.3f} \\\\"
+                f"{rfc_cdev:.3f} & {fues_cdev:.3f} & {dcegm_cdev:.3f} & {consav_cdev:.3f} \\\\"
             )
         else:
             tex_lines.append(

--- a/examples/retirement/tables.py
+++ b/examples/retirement/tables.py
@@ -31,7 +31,8 @@ def _format_params_list(params, latex=False):
     if not params:
         return []
 
-    param_order = ['r', 'beta', 'T', 'y', 'b', 'grid_max_A', 'm_bar', 'smooth_sigma']
+    param_order = ['r', 'beta', 'T', 'y', 'b', 'grid_max_A', 'm_bar', 'smooth_sigma',
+                   'true_grid_size', 'true_method']
     if latex:
         param_labels = {
             'r': 'r',
@@ -42,6 +43,8 @@ def _format_params_list(params, latex=False):
             'grid_max_A': r'$A_{\max}$',
             'm_bar': r'$\bar{m}$',
             'smooth_sigma': r'$\sigma$',
+            'true_grid_size': r'$N_{\text{true}}$',
+            'true_method': 'True method',
         }
     else:
         param_labels = {
@@ -53,6 +56,8 @@ def _format_params_list(params, latex=False):
             'grid_max_A': 'A_max',
             'm_bar': 'm̄ (FUES threshold)',
             'smooth_sigma': 'σ (smoothing)',
+            'true_grid_size': 'N_true (ref grid)',
+            'true_method': 'True method',
         }
 
     param_strs = []
@@ -70,14 +75,18 @@ def _format_params_list(params, latex=False):
     return param_strs
 
 
-def generate_timing_table(data, table_type, caption, results_dir="results", params=None):
-    """Generate markdown and LaTeX tables with total solution time performance.
+def generate_timing_table_combined(ue_data, total_data, table_type, caption,
+                                   results_dir="results", params=None):
+    """Generate timing table with UE and Total sub-columns per method.
 
     Parameters
     ----------
-    data : list of lists
-        Data for RFC, FUES, DCEGM, CONSAV total solution timings.
-        Each row: [grid_size, delta, rfc_time, fues_time, dcegm_time, consav_time]
+    ue_data : list of lists
+        Upper envelope timing data.
+        Each row: [grid_size, delta, rfc_ue, fues_ue, dcegm_ue, consav_ue]
+    total_data : list of lists
+        Total solution timing data.
+        Each row: [grid_size, delta, rfc_tot, fues_tot, dcegm_tot, consav_tot]
     table_type : str
         Type of the table for labeling the output file.
     caption : str
@@ -89,23 +98,33 @@ def generate_timing_table(data, table_type, caption, results_dir="results", para
     """
     os.makedirs(results_dir, exist_ok=True)
 
+    # Group data by grid size
+    grid_groups = {}
+    for ue_row, tot_row in zip(ue_data, total_data):
+        grid = int(ue_row[0])
+        if grid not in grid_groups:
+            grid_groups[grid] = []
+        grid_groups[grid].append((ue_row, tot_row))
+
     # --- Markdown output ---
     md_lines = []
-    md_lines.append(f"# {caption} - Total Solution Time (ms)\n")
-    md_lines.append("| Grid | Delta | RFC | FUES | DCEGM | CONSAV |")
-    md_lines.append("|------|-------|-----|------|-------|--------|")
+    md_lines.append(f"# {caption} - Timing (ms)\n")
+    md_lines.append("|      |       |    RFC    |    FUES   |   DCEGM   |  CONSAV   |")
+    md_lines.append("| Grid | δ     | UE  | Tot | UE  | Tot | UE  | Tot | UE  | Tot |")
+    md_lines.append("|------|-------|-----|-----|-----|-----|-----|-----|-----|-----|")
 
-    for row in data:
-        grid_size = int(row[0])
-        delta = row[1]
-        rfc_time = row[2]
-        fues_time = row[3]
-        dcegm_time = row[4]
-        consav_time = row[5]
-        md_lines.append(
-            f"| {grid_size} | {delta:.2f} | {rfc_time:.3f} | {fues_time:.3f} | "
-            f"{dcegm_time:.3f} | {consav_time:.3f} |"
-        )
+    for grid in sorted(grid_groups.keys()):
+        rows = grid_groups[grid]
+        for i, (ue_row, tot_row) in enumerate(rows):
+            delta = ue_row[1]
+            grid_str = str(grid) if i == 0 else ""
+            md_lines.append(
+                f"| {grid_str:4} | {delta:.2f} | "
+                f"{ue_row[2]:.2f} | {tot_row[2]:.2f} | "
+                f"{ue_row[3]:.2f} | {tot_row[3]:.2f} | "
+                f"{ue_row[4]:.2f} | {tot_row[4]:.2f} | "
+                f"{ue_row[5]:.2f} | {tot_row[5]:.2f} |"
+            )
 
     md_lines.append(_format_params_caption_md(params))
 
@@ -118,24 +137,30 @@ def generate_timing_table(data, table_type, caption, results_dir="results", para
     tex_lines = []
     tex_lines.append(r"\begin{table}[htbp]")
     tex_lines.append(r"\centering")
-    tex_lines.append(r"\caption{" + caption + " -- Total Solution Time (ms)}")
+    tex_lines.append(r"\caption{" + caption + " -- Timing (ms)}")
     tex_lines.append(r"\label{tab:" + table_type + "}")
-    tex_lines.append(r"\begin{tabular}{cccccc}")
+    tex_lines.append(r"\begin{tabular}{cc|cc|cc|cc|cc}")
     tex_lines.append(r"\toprule")
-    tex_lines.append(r"Grid & $\delta$ & RFC & FUES & DCEGM & CONSAV \\")
+    tex_lines.append(r" & & \multicolumn{2}{c|}{RFC} & \multicolumn{2}{c|}{FUES} & "
+                     r"\multicolumn{2}{c|}{DCEGM} & \multicolumn{2}{c}{CONSAV} \\")
+    tex_lines.append(r"Grid & $\delta$ & UE & Tot & UE & Tot & UE & Tot & UE & Tot \\")
     tex_lines.append(r"\midrule")
 
-    for row in data:
-        grid_size = int(row[0])
-        delta = row[1]
-        rfc_time = row[2]
-        fues_time = row[3]
-        dcegm_time = row[4]
-        consav_time = row[5]
-        tex_lines.append(
-            f"{grid_size} & {delta:.2f} & {rfc_time:.3f} & {fues_time:.3f} & "
-            f"{dcegm_time:.3f} & {consav_time:.3f} \\\\"
-        )
+    for grid in sorted(grid_groups.keys()):
+        rows = grid_groups[grid]
+        for i, (ue_row, tot_row) in enumerate(rows):
+            delta = ue_row[1]
+            grid_str = str(grid) if i == 0 else ""
+            tex_lines.append(
+                f"{grid_str} & {delta:.2f} & "
+                f"{ue_row[2]:.2f} & {tot_row[2]:.2f} & "
+                f"{ue_row[3]:.2f} & {tot_row[3]:.2f} & "
+                f"{ue_row[4]:.2f} & {tot_row[4]:.2f} & "
+                f"{ue_row[5]:.2f} & {tot_row[5]:.2f} \\\\"
+            )
+        # Add slight spacing between grid groups
+        if grid != max(grid_groups.keys()):
+            tex_lines.append(r"\addlinespace[0.5em]")
 
     tex_lines.append(r"\bottomrule")
     tex_lines.append(r"\end{tabular}")
@@ -152,8 +177,111 @@ def generate_timing_table(data, table_type, caption, results_dir="results", para
     return md_path, tex_path
 
 
-def generate_results_table(data, errors, table_type, caption, results_dir="results", params=None):
-    """Generate markdown and LaTeX tables with timing and Euler errors.
+def generate_accuracy_table(euler_data, cdev_data, table_type, caption,
+                            results_dir="results", params=None):
+    """Generate accuracy table with Euler and Cons.Dev sub-columns per method.
+
+    Parameters
+    ----------
+    euler_data : list of lists
+        Euler equation error data.
+        Each row: [grid_size, delta, rfc_err, fues_err, dcegm_err, consav_err]
+    cdev_data : list of lists
+        Consumption deviation data.
+        Each row: [grid_size, delta, rfc_cdev, fues_cdev, dcegm_cdev, consav_cdev]
+    table_type : str
+        Type of the table for labeling the output file.
+    caption : str
+        Caption/title for the table.
+    results_dir : str
+        Directory to save results. Default is "results".
+    params : dict, optional
+        Model parameters to include in caption.
+    """
+    os.makedirs(results_dir, exist_ok=True)
+
+    # Group data by grid size
+    grid_groups = {}
+    for euler_row, cdev_row in zip(euler_data, cdev_data):
+        grid = int(euler_row[0])
+        if grid not in grid_groups:
+            grid_groups[grid] = []
+        grid_groups[grid].append((euler_row, cdev_row))
+
+    # --- Markdown output ---
+    md_lines = []
+    md_lines.append(f"# {caption} - Accuracy (log₁₀)\n")
+    md_lines.append("|      |       |     RFC     |    FUES     |    DCEGM    |   CONSAV    |")
+    md_lines.append("| Grid | δ     | Euler | Dev | Euler | Dev | Euler | Dev | Euler | Dev |")
+    md_lines.append("|------|-------|-------|-----|-------|-----|-------|-----|-------|-----|")
+
+    for grid in sorted(grid_groups.keys()):
+        rows = grid_groups[grid]
+        for i, (euler_row, cdev_row) in enumerate(rows):
+            delta = euler_row[1]
+            grid_str = str(grid) if i == 0 else ""
+            md_lines.append(
+                f"| {grid_str:4} | {delta:.2f} | "
+                f"{euler_row[2]:.2f} | {cdev_row[2]:.2f} | "
+                f"{euler_row[3]:.2f} | {cdev_row[3]:.2f} | "
+                f"{euler_row[4]:.2f} | {cdev_row[4]:.2f} | "
+                f"{euler_row[5]:.2f} | {cdev_row[5]:.2f} |"
+            )
+
+    md_lines.append(_format_params_caption_md(params))
+
+    md_path = os.path.join(results_dir, f"retirement_{table_type}.md")
+    with open(md_path, "w") as f:
+        f.write("\n".join(md_lines))
+    print(f"Markdown table saved to: {md_path}")
+
+    # --- LaTeX output ---
+    tex_lines = []
+    tex_lines.append(r"\begin{table}[htbp]")
+    tex_lines.append(r"\centering")
+    tex_lines.append(r"\caption{" + caption + r" -- Accuracy ($\log_{10}$)}")
+    tex_lines.append(r"\label{tab:" + table_type + "}")
+    tex_lines.append(r"\begin{tabular}{cc|cc|cc|cc|cc}")
+    tex_lines.append(r"\toprule")
+    tex_lines.append(r" & & \multicolumn{2}{c|}{RFC} & \multicolumn{2}{c|}{FUES} & "
+                     r"\multicolumn{2}{c|}{DCEGM} & \multicolumn{2}{c}{CONSAV} \\")
+    tex_lines.append(r"Grid & $\delta$ & Euler & Dev & Euler & Dev & Euler & Dev & Euler & Dev \\")
+    tex_lines.append(r"\midrule")
+
+    for grid in sorted(grid_groups.keys()):
+        rows = grid_groups[grid]
+        for i, (euler_row, cdev_row) in enumerate(rows):
+            delta = euler_row[1]
+            grid_str = str(grid) if i == 0 else ""
+            tex_lines.append(
+                f"{grid_str} & {delta:.2f} & "
+                f"{euler_row[2]:.2f} & {cdev_row[2]:.2f} & "
+                f"{euler_row[3]:.2f} & {cdev_row[3]:.2f} & "
+                f"{euler_row[4]:.2f} & {cdev_row[4]:.2f} & "
+                f"{euler_row[5]:.2f} & {cdev_row[5]:.2f} \\\\"
+            )
+        # Add slight spacing between grid groups
+        if grid != max(grid_groups.keys()):
+            tex_lines.append(r"\addlinespace[0.5em]")
+
+    tex_lines.append(r"\bottomrule")
+    tex_lines.append(r"\end{tabular}")
+    if params:
+        tex_lines.append(r"\vspace{0.5em}")
+        tex_lines.append(r"\footnotesize{" + _format_params_caption_latex(params) + "}")
+    tex_lines.append(r"\end{table}")
+
+    tex_path = os.path.join(results_dir, f"retirement_{table_type}.tex")
+    with open(tex_path, "w") as f:
+        f.write("\n".join(tex_lines))
+    print(f"LaTeX table saved to: {tex_path}")
+
+    return md_path, tex_path
+
+
+def generate_results_table(data, errors, table_type, caption, results_dir="results",
+                           params=None, l2_data=None):
+    """Generate markdown and LaTeX tables with timing, Euler errors, and L2 deviation.
 
     Parameters
     ----------
@@ -171,16 +299,31 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
         Directory to save results. Default is "results".
     params : dict, optional
         Model parameters to include in caption.
+    l2_data : list of lists, optional
+        Data for consumption deviation from true solution (20k grid DCEGM).
+        Each row: [grid_size, delta, rfc_cdev, fues_cdev, dcegm_cdev, consav_cdev]
     """
     os.makedirs(results_dir, exist_ok=True)
+    include_l2 = l2_data is not None and len(l2_data) > 0
 
     # --- Markdown output ---
     md_lines = []
-    md_lines.append(f"# {caption} - Timing & Euler Errors\n")
-    md_lines.append("| Grid | Delta | RFC (ms) | FUES (ms) | DCEGM (ms) | CONSAV (ms) | RFC Err | FUES Err | DCEGM Err | CONSAV Err |")
-    md_lines.append("|------|-------|----------|-----------|------------|-------------|---------|----------|-----------|------------|")
+    if include_l2:
+        md_lines.append(f"# {caption} - Timing, Euler Errors & Cons. Deviation\n")
+        md_lines.append("| Grid | Delta | RFC (ms) | FUES (ms) | DCEGM (ms) | CONSAV (ms) | "
+                        "RFC Err | FUES Err | DCEGM Err | CONSAV Err | "
+                        "RFC CDev | FUES CDev | DCEGM CDev | CONSAV CDev |")
+        md_lines.append("|------|-------|----------|-----------|------------|-------------|"
+                        "---------|----------|-----------|------------|"
+                        "----------|-----------|------------|-------------|")
+    else:
+        md_lines.append(f"# {caption} - Timing & Euler Errors\n")
+        md_lines.append("| Grid | Delta | RFC (ms) | FUES (ms) | DCEGM (ms) | CONSAV (ms) | "
+                        "RFC Err | FUES Err | DCEGM Err | CONSAV Err |")
+        md_lines.append("|------|-------|----------|-----------|------------|-------------|"
+                        "---------|----------|-----------|------------|")
 
-    for row, error_row in zip(data, errors):
+    for i, (row, error_row) in enumerate(zip(data, errors)):
         grid_size = int(row[0])
         delta = row[1]
         rfc_time = row[2]
@@ -193,11 +336,24 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
         dcegm_error = error_row[4]
         consav_error = error_row[5]
 
-        md_lines.append(
-            f"| {grid_size} | {delta:.2f} | {rfc_time:.3f} | {fues_time:.3f} | "
-            f"{dcegm_time:.3f} | {consav_time:.3f} | {rfc_error:.3f} | "
-            f"{fues_error:.3f} | {dcegm_error:.3f} | {consav_error:.3f} |"
-        )
+        if include_l2:
+            l2_row = l2_data[i]
+            rfc_l2 = l2_row[2]
+            fues_l2 = l2_row[3]
+            dcegm_l2 = l2_row[4]
+            consav_l2 = l2_row[5]
+            md_lines.append(
+                f"| {grid_size} | {delta:.2f} | {rfc_time:.3f} | {fues_time:.3f} | "
+                f"{dcegm_time:.3f} | {consav_time:.3f} | {rfc_error:.3f} | "
+                f"{fues_error:.3f} | {dcegm_error:.3f} | {consav_error:.3f} | "
+                f"{rfc_l2:.3f} | {fues_l2:.3f} | {dcegm_l2:.3f} | {consav_l2:.3f} |"
+            )
+        else:
+            md_lines.append(
+                f"| {grid_size} | {delta:.2f} | {rfc_time:.3f} | {fues_time:.3f} | "
+                f"{dcegm_time:.3f} | {consav_time:.3f} | {rfc_error:.3f} | "
+                f"{fues_error:.3f} | {dcegm_error:.3f} | {consav_error:.3f} |"
+            )
 
     md_lines.append(_format_params_caption_md(params))
 
@@ -210,16 +366,28 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
     tex_lines = []
     tex_lines.append(r"\begin{table}[htbp]")
     tex_lines.append(r"\centering")
-    tex_lines.append(r"\caption{" + caption + " -- Timing and Euler Errors}")
-    tex_lines.append(r"\label{tab:" + table_type + "}")
-    tex_lines.append(r"\begin{tabular}{cccccccccc}")
-    tex_lines.append(r"\toprule")
-    tex_lines.append(r"Grid & $\delta$ & \multicolumn{4}{c}{Time (ms)} & \multicolumn{4}{c}{Euler Error} \\")
-    tex_lines.append(r"\cmidrule(lr){3-6} \cmidrule(lr){7-10}")
-    tex_lines.append(r" & & RFC & FUES & DCEGM & CONSAV & RFC & FUES & DCEGM & CONSAV \\")
+    if include_l2:
+        tex_lines.append(r"\caption{" + caption + " -- Timing, Euler Errors, and Cons. Deviation}")
+        tex_lines.append(r"\label{tab:" + table_type + "}")
+        tex_lines.append(r"\begin{tabular}{cccccccccccccc}")
+        tex_lines.append(r"\toprule")
+        tex_lines.append(r"Grid & $\delta$ & \multicolumn{4}{c}{Time (ms)} & "
+                         r"\multicolumn{4}{c}{Euler Error} & \multicolumn{4}{c}{Cons. Dev.} \\")
+        tex_lines.append(r"\cmidrule(lr){3-6} \cmidrule(lr){7-10} \cmidrule(lr){11-14}")
+        tex_lines.append(r" & & RFC & FUES & DCEGM & CONSAV & RFC & FUES & DCEGM & CONSAV & "
+                         r"RFC & FUES & DCEGM & CONSAV \\")
+    else:
+        tex_lines.append(r"\caption{" + caption + " -- Timing and Euler Errors}")
+        tex_lines.append(r"\label{tab:" + table_type + "}")
+        tex_lines.append(r"\begin{tabular}{cccccccccc}")
+        tex_lines.append(r"\toprule")
+        tex_lines.append(r"Grid & $\delta$ & \multicolumn{4}{c}{Time (ms)} & "
+                         r"\multicolumn{4}{c}{Euler Error} \\")
+        tex_lines.append(r"\cmidrule(lr){3-6} \cmidrule(lr){7-10}")
+        tex_lines.append(r" & & RFC & FUES & DCEGM & CONSAV & RFC & FUES & DCEGM & CONSAV \\")
     tex_lines.append(r"\midrule")
 
-    for row, error_row in zip(data, errors):
+    for i, (row, error_row) in enumerate(zip(data, errors)):
         grid_size = int(row[0])
         delta = row[1]
         rfc_time = row[2]
@@ -232,11 +400,24 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
         dcegm_error = error_row[4]
         consav_error = error_row[5]
 
-        tex_lines.append(
-            f"{grid_size} & {delta:.2f} & {rfc_time:.3f} & {fues_time:.3f} & "
-            f"{dcegm_time:.3f} & {consav_time:.3f} & {rfc_error:.3f} & "
-            f"{fues_error:.3f} & {dcegm_error:.3f} & {consav_error:.3f} \\\\"
-        )
+        if include_l2:
+            l2_row = l2_data[i]
+            rfc_l2 = l2_row[2]
+            fues_l2 = l2_row[3]
+            dcegm_l2 = l2_row[4]
+            consav_l2 = l2_row[5]
+            tex_lines.append(
+                f"{grid_size} & {delta:.2f} & {rfc_time:.3f} & {fues_time:.3f} & "
+                f"{dcegm_time:.3f} & {consav_time:.3f} & {rfc_error:.3f} & "
+                f"{fues_error:.3f} & {dcegm_error:.3f} & {consav_error:.3f} & "
+                f"{rfc_l2:.3f} & {fues_l2:.3f} & {dcegm_l2:.3f} & {consav_l2:.3f} \\\\"
+            )
+        else:
+            tex_lines.append(
+                f"{grid_size} & {delta:.2f} & {rfc_time:.3f} & {fues_time:.3f} & "
+                f"{dcegm_time:.3f} & {consav_time:.3f} & {rfc_error:.3f} & "
+                f"{fues_error:.3f} & {dcegm_error:.3f} & {consav_error:.3f} \\\\"
+            )
 
     tex_lines.append(r"\bottomrule")
     tex_lines.append(r"\end{tabular}")

--- a/examples/retirement/tables.py
+++ b/examples/retirement/tables.py
@@ -338,15 +338,15 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
 
         if include_l2:
             l2_row = l2_data[i]
-            rfc_l2 = l2_row[2]
-            fues_l2 = l2_row[3]
-            dcegm_l2 = l2_row[4]
-            consav_l2 = l2_row[5]
+            rfc_cdev = l2_row[2]
+            fues_cdev = l2_row[3]
+            dcegm_cdev = l2_row[4]
+            consav_cdev = l2_row[5]
             md_lines.append(
                 f"| {grid_size} | {delta:.2f} | {rfc_time:.3f} | {fues_time:.3f} | "
                 f"{dcegm_time:.3f} | {consav_time:.3f} | {rfc_error:.3f} | "
                 f"{fues_error:.3f} | {dcegm_error:.3f} | {consav_error:.3f} | "
-                f"{rfc_l2:.3f} | {fues_l2:.3f} | {dcegm_l2:.3f} | {consav_l2:.3f} |"
+                f"{rfc_cdev:.3f} | {fues_cdev:.3f} | {dcegm_cdev:.3f} | {consav_cdev:.3f} |"
             )
         else:
             md_lines.append(

--- a/examples/retirement/tables.py
+++ b/examples/retirement/tables.py
@@ -280,8 +280,8 @@ def generate_accuracy_table(euler_data, cdev_data, table_type, caption,
 
 
 def generate_results_table(data, errors, table_type, caption, results_dir="results",
-                           params=None, l2_data=None):
-    """Generate markdown and LaTeX tables with timing, Euler errors, and L2 deviation.
+                           params=None, cdev_data=None):
+    """Generate markdown and LaTeX tables with timing, Euler errors, and consumption deviation.
 
     Parameters
     ----------
@@ -299,16 +299,16 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
         Directory to save results. Default is "results".
     params : dict, optional
         Model parameters to include in caption.
-    l2_data : list of lists, optional
+    cdev_data : list of lists, optional
         Data for consumption deviation from reference solution.
         Each row: [grid_size, delta, rfc_cdev, fues_cdev, dcegm_cdev, consav_cdev]
     """
     os.makedirs(results_dir, exist_ok=True)
-    include_l2 = l2_data is not None and len(l2_data) > 0
+    include_cdev = cdev_data is not None and len(cdev_data) > 0
 
     # --- Markdown output ---
     md_lines = []
-    if include_l2:
+    if include_cdev:
         md_lines.append(f"# {caption} - Timing, Euler Errors & Cons. Deviation\n")
         md_lines.append("| Grid | Delta | RFC (ms) | FUES (ms) | DCEGM (ms) | CONSAV (ms) | "
                         "RFC Err | FUES Err | DCEGM Err | CONSAV Err | "
@@ -336,12 +336,12 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
         dcegm_error = error_row[4]
         consav_error = error_row[5]
 
-        if include_l2:
-            l2_row = l2_data[i]
-            rfc_cdev = l2_row[2]
-            fues_cdev = l2_row[3]
-            dcegm_cdev = l2_row[4]
-            consav_cdev = l2_row[5]
+        if include_cdev:
+            cdev_row = cdev_data[i]
+            rfc_cdev = cdev_row[2]
+            fues_cdev = cdev_row[3]
+            dcegm_cdev = cdev_row[4]
+            consav_cdev = cdev_row[5]
             md_lines.append(
                 f"| {grid_size} | {delta:.2f} | {rfc_time:.3f} | {fues_time:.3f} | "
                 f"{dcegm_time:.3f} | {consav_time:.3f} | {rfc_error:.3f} | "
@@ -366,7 +366,7 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
     tex_lines = []
     tex_lines.append(r"\begin{table}[htbp]")
     tex_lines.append(r"\centering")
-    if include_l2:
+    if include_cdev:
         tex_lines.append(r"\caption{" + caption + " -- Timing, Euler Errors, and Cons. Deviation}")
         tex_lines.append(r"\label{tab:" + table_type + "}")
         tex_lines.append(r"\begin{tabular}{cccccccccccccc}")
@@ -400,12 +400,12 @@ def generate_results_table(data, errors, table_type, caption, results_dir="resul
         dcegm_error = error_row[4]
         consav_error = error_row[5]
 
-        if include_l2:
-            l2_row = l2_data[i]
-            rfc_cdev = l2_row[2]
-            fues_cdev = l2_row[3]
-            dcegm_cdev = l2_row[4]
-            consav_cdev = l2_row[5]
+        if include_cdev:
+            cdev_row = cdev_data[i]
+            rfc_cdev = cdev_row[2]
+            fues_cdev = cdev_row[3]
+            dcegm_cdev = cdev_row[4]
+            consav_cdev = cdev_row[5]
             tex_lines.append(
                 f"{grid_size} & {delta:.2f} & {rfc_time:.3f} & {fues_time:.3f} & "
                 f"{dcegm_time:.3f} & {consav_time:.3f} & {rfc_error:.3f} & "

--- a/experiments/retirement/README.md
+++ b/experiments/retirement/README.md
@@ -58,7 +58,44 @@ qsub experiments/retirement/retirement_timings.sh
 
 Results saved to `FUES/results/retirement/`:
 - `plots/` - PNG figures
-- `tables/` - Markdown tables (when RUN_TIMINGS=true)
+- `retirement_timing.tex/.md` - Timing table (UE and Total time per method)
+- `retirement_accuracy.tex/.md` - Accuracy table (Euler error and consumption deviation)
+
+## Benchmark Metrics
+
+The timing benchmarks compare four upper envelope methods: **RFC**, **FUES**, **DCEGM**, and **CONSAV**.
+
+### Timing Table
+- **UE**: Average upper envelope computation time per period (ms)
+- **Tot**: Total solution time including all periods (ms)
+
+### Accuracy Table
+- **Euler**: Euler equation error, `log₁₀(|u'(c) - βR·E[u'(c')]| / u'(c))`
+- **Dev**: Consumption deviation from true solution, `log₁₀(|c - c_true| / c_true)`
+
+The "true" reference solution is computed using a high-resolution grid (default: 20,000 points with DCEGM). This is configurable via YAML parameters.
+
+## Parameter Configuration
+
+Model and benchmark parameters are configured via YAML files in `params/`:
+
+```yaml
+# params/baseline.yml
+model:
+  r: 0.02
+  beta: 0.98
+  delta: 1.0
+  # ... other model params
+
+benchmark:
+  true_grid_size: 20000  # Grid size for reference solution
+  true_method: DCEGM     # Method for reference (RFC, FUES, DCEGM, CONSAV)
+```
+
+Use different parameter files:
+```bash
+python experiments/retirement/run_experiment.py --params params/long_horizon.yml --run-timings
+```
 
 ## Files
 

--- a/experiments/retirement/README.md
+++ b/experiments/retirement/README.md
@@ -1,6 +1,6 @@
 # Retirement Model Experiments
 
-Timing comparison of FUES vs DC-EGM for the Ishkakov et al (2017) retirement model.
+Timing comparison of FUES vs DC-EGM vs CONSAV for the Ishkakov et al (2017) retirement model.
 
 ## Quick Start
 

--- a/experiments/retirement/params/baseline.yml
+++ b/experiments/retirement/params/baseline.yml
@@ -11,3 +11,7 @@ model:
   T: 20                # Number of periods
   smooth_sigma: 0      # Smoothing parameter (0 = no smoothing)
   m_bar: 1.2           # FUES jump detection threshold
+
+benchmark:
+  true_grid_size: 20000  # Grid size for "true" reference solution
+  true_method: DCEGM     # Method for "true" solution (RFC, FUES, DCEGM, CONSAV)

--- a/experiments/retirement/params/high_beta.yml
+++ b/experiments/retirement/params/high_beta.yml
@@ -11,3 +11,7 @@ model:
   T: 20
   smooth_sigma: 0
   m_bar: 1.2           # FUES jump detection threshold
+
+benchmark:
+  true_grid_size: 20000  # Grid size for "true" reference solution
+  true_method: DCEGM     # Method for "true" solution (RFC, FUES, DCEGM, CONSAV)

--- a/experiments/retirement/params/long_horizon.yml
+++ b/experiments/retirement/params/long_horizon.yml
@@ -12,3 +12,7 @@ model:
   smooth_sigma: 0
   m_bar: 1.2           # FUES jump detection threshold
   padding_mbar: -0.011 # For timing benchmarks
+
+benchmark:
+  true_grid_size: 20000  # Grid size for "true" reference solution
+  true_method: DCEGM     # Method for "true" solution (RFC, FUES, DCEGM, CONSAV)

--- a/experiments/retirement/params/low_delta.yml
+++ b/experiments/retirement/params/low_delta.yml
@@ -11,3 +11,7 @@ model:
   T: 20
   smooth_sigma: 0
   m_bar: 1.2           # FUES jump detection threshold
+
+benchmark:
+  true_grid_size: 20000  # Grid size for "true" reference solution
+  true_method: DCEGM     # Method for "true" solution (RFC, FUES, DCEGM, CONSAV)

--- a/experiments/retirement/retirement_timings.sh
+++ b/experiments/retirement/retirement_timings.sh
@@ -29,9 +29,9 @@ OUTPUT_DIR=""               # Leave empty for default (results/retirement)
 
 # Timing sweep settings
 RUN_TIMINGS=true           # Run full timing comparison (slow)
-SWEEP_GRIDS="500,1000,2000,3000,10000"   # Grid sizes for sweep
+SWEEP_GRIDS="1000,2000,3000,6000,10000"   # Grid sizes for sweep
 SWEEP_DELTAS="0.25,0.5,1,2"              # Delta values for sweep
-SWEEP_RUNS=3                             # Number of runs per config (best of n)
+SWEEP_RUNS=3                            # Number of runs per config (best of n)
 
 # ======================================================================
 #  ENVIRONMENT SETUP

--- a/experiments/retirement/run_experiment.py
+++ b/experiments/retirement/run_experiment.py
@@ -28,7 +28,7 @@ def parse_list(s, dtype=float):
 
 
 def load_params(params_file):
-    """Load model parameters from YAML file."""
+    """Load model and benchmark parameters from YAML file."""
     # Handle relative paths from script directory
     if not os.path.isabs(params_file):
         params_file = os.path.join(SCRIPT_DIR, params_file)
@@ -36,7 +36,9 @@ def load_params(params_file):
     with open(params_file, 'r') as f:
         config = yaml.safe_load(f)
 
-    return config.get('model', {})
+    model_params = config.get('model', {})
+    benchmark_params = config.get('benchmark', {})
+    return model_params, benchmark_params
 
 
 def main():
@@ -67,7 +69,7 @@ def main():
     args = parser.parse_args()
 
     # Load parameters from YAML
-    params = load_params(args.params)
+    params, benchmark_params = load_params(args.params)
     print(f'Loaded parameters from: {args.params}')
 
     # Setup output directories
@@ -86,13 +88,17 @@ def main():
         grid_sizes = parse_list(args.sweep_grids, int)
         delta_values = parse_list(args.sweep_deltas, float)
         m_bar = params.get('m_bar', 1.2)
+        true_grid_size = benchmark_params.get('true_grid_size', 20000)
+        true_method = benchmark_params.get('true_method', 'DCEGM')
         print(f'\nRunning timing comparison...')
         print(f'  Grid sizes: {grid_sizes}')
         print(f'  Delta values: {delta_values}')
         print(f'  Runs per config: {args.sweep_runs}')
         print(f'  m_bar: {m_bar}')
+        print(f'  True solution: {true_method} with {true_grid_size} grid points')
         test_Timings(grid_sizes, delta_values, n=args.sweep_runs,
-                     results_dir=args.output_dir, m_bar=m_bar)
+                     results_dir=args.output_dir, m_bar=m_bar,
+                     true_grid_size=true_grid_size, true_method=true_method)
 
     # Create model and solve
     print('\nCreating model and solving...')

--- a/src/dc_smm/models/retirement/retirement.py
+++ b/src/dc_smm/models/retirement/retirement.py
@@ -154,6 +154,49 @@ def euler(cp,sigma_work):
     return np.nanmean(euler)
 
 
+def consumption_deviation(cp, c_solution, c_true, a_grid_true):
+    """Compute mean log absolute deviation from high-resolution 'true' solution.
+
+    Uses the same metric as Euler error: log10(|c - c_true| / c_true).
+    Compares a solution computed on a coarser grid to a high-resolution
+    reference solution (e.g., DCEGM with 20,000 points).
+
+    Parameters
+    ----------
+    cp : RetirementModel
+        Model parameters for the solution being tested.
+    c_solution : ndarray (T x grid_size)
+        Consumption policy from method being tested.
+    c_true : ndarray (T x true_grid_size)
+        High-resolution "true" solution.
+    a_grid_true : ndarray
+        Asset grid for the true solution.
+
+    Returns
+    -------
+    float
+        Mean log10 absolute relative deviation across periods and grid points.
+    """
+    a_grid = cp.asset_grid_A
+    T = cp.T
+
+    deviations = np.zeros((T - 1, len(a_grid)))
+    deviations.fill(np.nan)
+
+    for t in range(T - 1):
+        # Interpolate true solution to the test grid
+        c_true_interp = np.interp(a_grid, a_grid_true, c_true[t])
+        c_test = c_solution[t]
+
+        for i_a in range(len(a_grid)):
+            if c_true_interp[i_a] > 1e-10 and c_test[i_a] > 1e-10:
+                # Same metric as Euler: log10(|c - c_true| / c_true)
+                rel_error = np.abs(c_test[i_a] - c_true_interp[i_a]) / c_true_interp[i_a]
+                deviations[t, i_a] = np.log10(rel_error + 1e-16)
+
+    return np.nanmean(deviations)
+
+
 def Operator_Factory(cp):
     """
     Operator takes in a RetirementModel and returns functions


### PR DESCRIPTION
- Add consumption_deviation() function to compare solutions against high-resolution reference (default: 20k grid DCEGM)
- Restructure benchmark tables into two cleaner formats:
  - Timing table with UE/Tot sub-columns per method
  - Accuracy table with Euler/Dev sub-columns per method
- Add configurable true_grid_size and true_method parameters to YAML config files under benchmark section
- Use 2 decimal places for timing values
- Grid-grouped rows with delta as sub-rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)